### PR TITLE
Command line API definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#19 <https://github.com/znicholls/silicone/pull/19>`_) Add releasing docs plus command-line entry point tests
 - (`#14 <https://github.com/znicholls/silicone/pull/14>`_) Add root-mean square closest pathway cruncher
 - (`#13 <https://github.com/znicholls/silicone/pull/13>`_) Get initial work (see `#11 <https://github.com/znicholls/silicone/pull/11>`_) into package structure, still requires tests (see `#16 <https://github.com/znicholls/silicone/pull/16>`_)
 - (`#12 <https://github.com/znicholls/silicone/pull/12>`_) Add BSD-3-Clause license

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ master
 - (`#13 <https://github.com/znicholls/silicone/pull/13>`_) Get initial work (see `#11 <https://github.com/znicholls/silicone/pull/11>`_) into package structure, still requires tests (see `#16 <https://github.com/znicholls/silicone/pull/16>`_)
 - (`#12 <https://github.com/znicholls/silicone/pull/12>`_) Add BSD-3-Clause license
 - (`#9 <https://github.com/znicholls/silicone/pull/9>`_) Add lead gas cruncher
+- (`#8 <https://github.com/znicholls/silicone/pull/8>`_) Add sketch of basic command line interface
 - (`#6 <https://github.com/znicholls/silicone/pull/6>`_) Update development docs
 - (`#5 <https://github.com/znicholls/silicone/pull/5>`_) Put notebooks under CI
 - (`#4 <https://github.com/znicholls/silicone/pull/4>`_) Add basic documentation structure

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Silicone
 | Latest activity | |Contributors| | |Last Commit| | |Commits Since Last Release| |
 +-----------------+----------------+---------------+------------------------------+
 
+.. sec-begin-long-description
 .. sec-begin-index
 
 Silicone is a Python package which can be used to automatically fill in detail in emissions scenarios.
@@ -32,6 +33,7 @@ License
 Silicone is free software under a BSD 3-Clause License, see `LICENSE <https://github.com/znicholls/silicone/blob/master/LICENSE>`_.
 
 .. sec-end-license
+.. sec-end-long-description
 
 .. sec-begin-installation
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -6,3 +6,7 @@ CLI API
 .. click:: silicone.cli:plot_emission_correlations_cruncher_quantile_rolling_windows_cli
    :prog: silicone-explore-quantiles-rolling-windows
    :show-nested:
+
+.. click:: silicone.cli:infill
+   :prog: silicone-infill
+   :show-nested:

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -3,6 +3,6 @@
 CLI API
 -------
 
-.. click:: silicone.cli:plot_emission_correlations_cli
-   :prog: silicone-explore-quantiles
+.. click:: silicone.cli:plot_emission_correlations_cruncher_quantile_rolling_windows_cli
+   :prog: silicone-explore-quantiles-rolling-windows
    :show-nested:

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -143,8 +143,42 @@ For more information on these, `here is the full guide <https://numpydoc.readthe
 Releasing
 ---------
 
-Instructions on how to release versions of silicone will go here.
+First step
+~~~~~~~~~~
 
+#. Test installation with dependencies ``make test-install``
+#. Update ``CHANGELOG.rst``:
+
+    - add a header for the new version between ``master`` and the latest bullet point
+    - this should leave the section underneath the master header empty
+
+#. ``git add .``
+#. ``git commit -m "Prepare for release of vX.Y.Z"``
+#. Test version updated as intended with ``make test-install``
+
+PyPI
+~~~~
+
+If uploading to PyPI, do the following (otherwise skip these steps)
+
+#. ``make publish-on-testpypi``
+#. Go to `test PyPI <https://test.pypi.org/project/silicone/>`_ and check that the new release is as intended. If it isn't, stop and debug.
+#. Test the install with ``make test-testpypi-install`` (this doesn't test all the imports as most required packages are not on test PyPI).
+
+Assuming test PyPI worked, now upload to the main repository
+
+#. ``make publish-on-pypi``
+#. Go to `Silicone's PyPI`_ and check that the new release is as intended.
+#. Test the install with ``make test-pypi-install``
+
+Push to repository
+~~~~~~~~~~~~~~~~~~
+
+Finally, push the tags and commit to the repository
+
+#. ``git push``
+#. ``git tag vX.Y.Z``
+#. ``git push --tags``
 
 Why is there a ``Makefile`` in a pure Python repository?
 --------------------------------------------------------
@@ -154,3 +188,4 @@ Hence we have one here which basically acts as a notes file for how to do all th
 
 .. _Sphinx: http://www.sphinx-doc.org/en/master/
 .. _Silicone issue tracker: https://github.com/znicholls/netcdf-scm/issues
+.. _`Silicone's PyPI`: https://pypi.org/project/silicone/

--- a/scripts/test_install.py
+++ b/scripts/test_install.py
@@ -3,7 +3,6 @@ Thanks https://stackoverflow.com/a/25562415/10473080
 """
 import importlib
 import pkgutil
-import sys
 
 import silicone
 

--- a/scripts/test_install.py
+++ b/scripts/test_install.py
@@ -3,6 +3,7 @@ Thanks https://stackoverflow.com/a/25562415/10473080
 """
 import importlib
 import pkgutil
+import sys
 
 import silicone
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,17 @@ REQUIREMENTS_DOCS = [
 ]
 REQUIREMENTS_DEPLOY = ["setuptools>=38.6.0", "twine>=1.11.0", "wheel>=0.31.0"]
 REQUIREMENTS_DEV = (
-    ["black", "bandit", "coverage", "flake8", "isort", "mypy", "pydocstyle", "pylint"]
+    [
+        "black",
+        "bandit",
+        "coverage",
+        "flake8",
+        "isort",
+        "mypy",
+        "pydocstyle",
+        "pylint",
+        "pytest-console-scripts",
+    ]
     + REQUIREMENTS_NOTEBOOKS
     + REQUIREMENTS_TESTS
     + REQUIREMENTS_DOCS
@@ -73,7 +83,7 @@ REQUIREMENTS_EXTRAS = {
 }
 
 # Get the long description from the README file
-with open(README, "r", encoding="utf-8") as f:
+with open(README, "r") as f:
     README_LINES = ["Silicone", "========", ""]
     add_line = False
     for line in f:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,13 @@ REQUIREMENTS_INSTALL = [
     "click",
 ]
 REQUIREMENTS_NOTEBOOKS = ["matplotlib", "notebook", "seaborn", "statsmodels"]
-REQUIREMENTS_TESTS = ["codecov", "nbval", "pytest>=4.0,<5.0", "pytest-cov"]
+REQUIREMENTS_TESTS = [
+    "codecov",
+    "nbval",
+    "pytest>=4.0,<5.0",
+    "pytest-console-scripts",
+    "pytest-cov",
+]
 REQUIREMENTS_DOCS = [
     "sphinx>=1.4,<2.1",
     "sphinx_rtd_theme",
@@ -56,17 +62,7 @@ REQUIREMENTS_DOCS = [
 ]
 REQUIREMENTS_DEPLOY = ["setuptools>=38.6.0", "twine>=1.11.0", "wheel>=0.31.0"]
 REQUIREMENTS_DEV = (
-    [
-        "black",
-        "bandit",
-        "coverage",
-        "flake8",
-        "isort",
-        "mypy",
-        "pydocstyle",
-        "pylint",
-        "pytest-console-scripts",
-    ]
+    ["black", "bandit", "coverage", "flake8", "isort", "mypy", "pydocstyle", "pylint"]
     + REQUIREMENTS_NOTEBOOKS
     + REQUIREMENTS_TESTS
     + REQUIREMENTS_DOCS

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ CLASSIFIERS = [
 ENTRY_POINTS = {
     "console_scripts": [
         "silicone-explore-quantiles-rolling-windows = silicone.cli:plot_emission_correlations_cruncher_quantile_rolling_windows_cli"
+        "silicone-infill = silicone.cli:infill",
     ]
 }
 

--- a/src/silicone/cli.py
+++ b/src/silicone/cli.py
@@ -91,12 +91,20 @@ def plot_emission_correlations_cruncher_quantile_rolling_windows_cli(
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
-@click.argument("scenarios_raw", type=click.Path(exists=True, readable=True, resolve_path=True))
-@click.argument("scenarios_db", type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.argument(
-    "scenarios_output", type=click.Path(writable=True, resolve_path=True)
+    "scenarios_raw", type=click.Path(exists=True, readable=True, resolve_path=True)
 )
-@click.option("--config", default=None, type=click.Path(readable=True, resolve_path=True), show_default=True, help="Configuration to use when infilling (this should be a yaml file)")
+@click.argument(
+    "scenarios_db", type=click.Path(exists=True, readable=True, resolve_path=True)
+)
+@click.argument("scenarios_output", type=click.Path(writable=True, resolve_path=True))
+@click.option(
+    "--config",
+    default=None,
+    type=click.Path(readable=True, resolve_path=True),
+    show_default=True,
+    help="Configuration to use when infilling (this should be a yaml file).",
+)
 def infill(scenarios_raw, scenarios_db, scenarios_output, config):
     r"""
     In fill data in ``scenarios_raw`` using information from ``scenarios_db``.

--- a/src/silicone/cli.py
+++ b/src/silicone/cli.py
@@ -88,3 +88,23 @@ def plot_emission_correlations_cruncher_quantile_rolling_windows_cli(
         model_colours,
         legend_fraction,
     )
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("scenarios_raw", type=click.Path(exists=True, readable=True, resolve_path=True))
+@click.argument("scenarios_db", type=click.Path(exists=True, readable=True, resolve_path=True))
+@click.argument(
+    "scenarios_output", type=click.Path(writable=True, resolve_path=True)
+)
+@click.option("--config", default=None, type=click.Path(readable=True, resolve_path=True), show_default=True, help="Configuration to use when infilling (this should be a yaml file)")
+def infill(scenarios_raw, scenarios_db, scenarios_output, config):
+    r"""
+    In fill data in ``scenarios_raw`` using information from ``scenarios_db``.
+
+    The output is written in ``scenarios_output``.
+
+    The configuration to use for the run is read from ``config``. If ``config`` is not
+    supplied, the default config will be used. These can be found in
+    ``silicone.cli.default_infill_config``.
+    """
+    raise NotImplementedError

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.script_launch_mode("subprocess")
+@pytest.mark.parametrize("entry_point", ("silicone-explore-quantiles-rolling-windows",))
+def test_silicone_explore_quantiles_rolling_windows(entry_point, script_runner):
+    res = script_runner.run(entry_point, "--help")
+    assert res.success
+    assert res.stdout
+    assert res.stderr == ""


### PR DESCRIPTION
# Pull request

Define Silicone's command-line interface. This is just a sketch but should help us with later design decisions. My current think is that the workflow looks something like this:

1. User decides which scenarios they want to infill, which scenario database they want to use for doing the infilling (i.e. which scenario tells you how e.g. CH4 emissions relate to CO2 emissions) and where you want the outputs to go.
1. The user sets any other config in a yaml file
    - I don't know what options we want to offer yet, but putting it in a yaml file will make it pretty easy to extend in future
1. Then they just call `silicone-infill source_file database_file output_file --config user-config.yaml` and away it goes

I use the [click](https://palletsprojects.com/p/click/) package for command-line interfaces like this cause it's super simple. 

Please confirm that this pull request has done the following:

- [x] Tests added (N/A)
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/znicholls/silicone/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/znicholls/silicone/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/znicholls/silicone/issues/YY>`_)
```
