### PR TITLE
Change cruncher names zn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,16 @@ black: $(VENV_DIR)  ## use black to autoformat code
 		echo Not trying any formatting, working directory is dirty... >&2; \
 	fi;
 
+.PHONY: checks
+checks: $(VENV_DIR)  ## run checks similar to CI
+	@echo "=== black ==="; $(VENV_DIR)/bin/black --check src tests setup.py docs/source/conf.py --exclude silicone/_version.py || echo "--- black failed ---" >&2; \
+		echo "\n\n=== isort ==="; $(VENV_DIR)/bin/isort --check-only --quiet --recursive src tests setup.py || echo "--- isort failed ---" >&2; \
+		echo "\n\n=== docs ==="; $(VENV_DIR)/bin/sphinx-build -M html docs/source docs/build -qW || echo "--- docs failed ---" >&2; \
+		echo "\n\n=== notebook tests ==="; $(VENV_DIR)/bin/pytest notebooks -r a --nbval --sanitize-with tests/notebook-tests.cfg || echo "--- notebook tests failed ---" >&2; \
+		echo "\n\n=== tests ==="; $(VENV_DIR)/bin/pytest tests -r a --cov=silicone --cov-report='' \
+			&& $(VENV_DIR)/bin/coverage report --fail-under=95 || echo "--- tests failed ---" >&2; \
+		echo
+
 .PHONY: test-all
 test-all:  ## run the testsuite and test the notebooks
 	make test

--- a/docs/source/database-crunchers.rst
+++ b/docs/source/database-crunchers.rst
@@ -12,10 +12,10 @@ Closest RMS cruncher API
 .. automodule:: silicone.database_crunchers.rms_closest
     :members:
 
-Lead gas cruncher API
+Latest Time Ratio API
 =====================
 
-.. automodule:: silicone.database_crunchers.lead_gas
+.. automodule:: silicone.database_crunchers.latest_time_ratio
     :members:
 
 


### PR DESCRIPTION
Gets the CI passing, also adds `checks` target to make which is intended to allow the CI workflow to be run locally.