### PR TITLE
Add failing test

### DIFF
--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import pandas as pd
 import pyam
+import pytest
 import scipy.interpolate
 
 import silicone.stats as stats
@@ -30,9 +31,12 @@ simple_df = pd.DataFrame(
 simple_df = pyam.IamDataFrame(simple_df)
 
 
-def test_rolling_window_find_quantiles():
-    xs = np.array([0, 0, 1, 1])
-    ys = np.array([0, 1, 0, 1])
+@pytest.mark.parametrize("xs,ys", (
+    (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1])),
+    (np.array([0, 0, 1, 1]), np.array([0, 1, 1, 0])),
+    (np.array([0, 1, 0, 1]), np.array([0, 1, 1, 0])),
+))
+def test_rolling_window_find_quantiles(xs, ys):
     desired_quantiles = [0.4, 0.5, 0.6]
     # We have points at 0 and 1 in both x and y. We set the decay length to 20 so 0
     # and 1 get weightings of 1/3 at their own end and 1/6 at the other end.


### PR DESCRIPTION
@Rlamboll here's an illustration of a bug where if you swap the order of the points you get a different answer (I finally got my head around how the weighting works in #86).

I think this forces us to make a choice about how we go forward. Either we a) push through these PRs (e.g. #86) on the assumption that they're doing what we want for the paper and we can deal with edge cases later or b) really dig into how these crunchers etc. are working and try and weed out all the edge cases now. 

a's pros: faster, paper can document what we want and the rest isn't important enough to worry about, a's cons: we're not completely sure that things work as intended in all cases and our documentation might leave a bit to be desired.

b's pros: by digging deep we can also produce really thorough documentation which will likely make silicone much easier for others to use. b's cons: you never know what you uncover as you dig, doing this thoroughly will take time which we might not have (I can't give enough time to thoroughly review lots of PRs so it might be a month or more before we settle everything).